### PR TITLE
Major dependency upgrades

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 
 buildscript {
 
-    val kotlinVersion = "2.1.0"
+    val kotlinVersion = "2.1.10"
 
     dependencies {
         classpath(kotlin("gradle-plugin", version = kotlinVersion))
@@ -13,9 +13,9 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "2.1.0" apply false
+    kotlin("multiplatform") version "2.1.10" apply false
     id("com.android.library") version "8.2.2" apply false
-    id("org.jetbrains.kotlinx.atomicfu") version "0.26.1"
+    id("org.jetbrains.kotlinx.atomicfu") version "0.27.0"
     id("com.vanniktech.maven.publish") version "0.30.0"
     //id("org.jetbrains.kotlin.android") version "2.0.0" apply false
     //id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 
 buildscript {
 
-    val kotlinVersion = "2.0.20"
+    val kotlinVersion = "2.1.0"
 
     dependencies {
         classpath(kotlin("gradle-plugin", version = kotlinVersion))
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "2.0.20" apply false
+    kotlin("multiplatform") version "2.1.0" apply false
     id("com.android.library") version "8.2.2" apply false
     id("org.jetbrains.kotlinx.atomicfu") version "0.26.1"
     id("com.vanniktech.maven.publish") version "0.30.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath(kotlin("gradle-plugin", version = kotlinVersion))
-        classpath("com.android.tools.build:gradle:8.2.2")
+        classpath("com.android.tools.build:gradle:8.7.3")
         classpath(kotlin("serialization", version = kotlinVersion))
     }
 
@@ -14,7 +14,7 @@ buildscript {
 
 plugins {
     kotlin("multiplatform") version "2.1.10" apply false
-    id("com.android.library") version "8.2.2" apply false
+    id("com.android.library") version "8.7.3" apply false
     id("org.jetbrains.kotlinx.atomicfu") version "0.27.0"
     id("com.vanniktech.maven.publish") version "0.30.0"
     //id("org.jetbrains.kotlin.android") version "2.0.0" apply false

--- a/rhodium-core/build.gradle.kts
+++ b/rhodium-core/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 val kotlinVersion = "2.1.0"
 val ktorVersion = "2.3.13"
 val kotlinCryptoVersion = "0.4.0"
-val secp256k1Version = "0.16.0"
+val secp256k1Version = "0.17.1"
 val junitJupiterVersion = "5.10.1"
 
 plugins {

--- a/rhodium-core/build.gradle.kts
+++ b/rhodium-core/build.gradle.kts
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 
-val kotlinVersion = "2.1.0"
-val ktorVersion = "2.3.13"
+val kotlinVersion = "2.1.10"
+val ktorVersion = "3.1.1"
 val kotlinCryptoVersion = "0.4.0"
 val secp256k1Version = "0.17.1"
 val junitJupiterVersion = "5.10.1"
@@ -42,11 +42,11 @@ kotlin {
     //explicitApi()
     jvmToolchain(17)
 
-    @OptIn(ExperimentalKotlinGradlePluginApi::class)
-    compilerOptions {
-        apiVersion.set(KotlinVersion.KOTLIN_1_8)
-        languageVersion.set(KotlinVersion.KOTLIN_1_8)
-    }
+//    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+//    compilerOptions {
+//        apiVersion.set(KotlinVersion.KOTLIN_2_0)
+//        languageVersion.set(KotlinVersion.KOTLIN_2_0)
+//    }
 
     jvm("commonJvm") {
 
@@ -130,11 +130,11 @@ kotlin {
             implementation("dev.whyoleg.cryptography:cryptography-random:$kotlinCryptoVersion")
 
             //Serialization
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
             //Coroutines
-            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
             //Atomics
-            implementation("org.jetbrains.kotlinx:atomicfu:0.26.1")
+            implementation("org.jetbrains.kotlinx:atomicfu:0.27.0")
             //Date-time
             implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
             //UUID

--- a/rhodium-core/build.gradle.kts
+++ b/rhodium-core/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 
-val kotlinVersion = "2.0.20"
+val kotlinVersion = "2.1.0"
 val ktorVersion = "2.3.13"
 val kotlinCryptoVersion = "0.4.0"
 val secp256k1Version = "0.16.0"


### PR DESCRIPTION
This upgrades the Kotlin version to 2.1.10, AGP to 8.7, Ktor, secp256k1-kmp to the latest, and all the Kotlinx libraries to their most recent versions.