### PR TITLE
Fix failing Ktor iOS tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,4 +51,4 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
         with:
-          arguments: ${{ matrix.target }}
+          arguments: ${{ matrix.target }} --no-configuration-cache

--- a/rhodium-core/build.gradle.kts
+++ b/rhodium-core/build.gradle.kts
@@ -26,7 +26,9 @@
 
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
+import java.io.ByteArrayOutputStream
 
 val coroutinesVersion = "1.10.1"
 val kotlinVersion = "2.1.10"
@@ -277,4 +279,29 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>() {
 
 tasks.withType<KotlinNativeCompile>().configureEach {
     compilerOptions.freeCompilerArgs.add("-opt-in=kotlinx.cinterop.ExperimentalForeignApi")
+}
+
+
+val deviceName = project.findProperty("iosDevice") as? String ?: "iPhone 16"
+
+tasks.register<Exec>("bootIOSSimulator") {
+    isIgnoreExitValue = true
+    val errorBuffer = ByteArrayOutputStream()
+    errorOutput = ByteArrayOutputStream()
+    commandLine("xcrun", "simctl", "boot", deviceName)
+
+    doLast {
+        val result = executionResult.get()
+        if (result.exitValue != 148 && result.exitValue != 149) { // ignoring device already booted errors
+            println(errorBuffer.toString())
+            result.assertNormalExitValue()
+        }
+    }
+}
+
+tasks.withType<KotlinNativeSimulatorTest>().configureEach {
+    dependsOn("bootIOSSimulator")
+    standalone.set(false)
+    device.set(deviceName)
+
 }

--- a/rhodium-core/build.gradle.kts
+++ b/rhodium-core/build.gradle.kts
@@ -305,3 +305,16 @@ tasks.withType<KotlinNativeSimulatorTest>().configureEach {
     device.set(deviceName)
 
 }
+
+tasks.register<Exec>("shutdownSimulator") {
+
+    val allSimulatorTests = tasks.withType<KotlinNativeSimulatorTest>()
+    if (allSimulatorTests.all { task -> task.state.failure == null }) {
+        commandLine("xcrun", "simctl", "shutdown", "booted")
+    }
+
+}
+
+tasks.named { it.contains("ios") && it.contains("Test") }.configureEach {
+    finalizedBy("shutdownSimulator")
+}

--- a/rhodium-core/src/commonTest/kotlin/rhodium/nostr/relay/RelayInfoTests.kt
+++ b/rhodium-core/src/commonTest/kotlin/rhodium/nostr/relay/RelayInfoTests.kt
@@ -23,7 +23,7 @@
  *
  */
 
-package rhodium.relay
+package rhodium.nostr.relay
 
 import io.ktor.client.HttpClient
 import io.ktor.http.URLBuilder
@@ -63,7 +63,9 @@ class RelayInfoTests {
             )
         )
 
-        val obtainedAndParsedInfo = Relay.Companion.fetchInfoFor(URLBuilder("wss://eden.nostr.land").buildString())
+        val obtainedAndParsedInfo = Relay.fetchInfoFor("wss://eden.nostr.land")
+        println("Obtained relay info: ")
+        println(obtainedAndParsedInfo)
 
         assertEquals(edenNostrLandInfo, obtainedAndParsedInfo)
     }


### PR DESCRIPTION
Running tests for Ktor on the iOS simulator fail, when they shouldn't(and they work well in a running simulator). This is an attempt to use actual running simulators(with resource efficiency in mind) when running the tests.